### PR TITLE
add office bearers page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,4 @@ GOOGLE_OAUTH2_KEY=replace_with_your_key
 GOOGLE_OAUTH2_SECRET=replace_with_your_secret
 
 # other configs
+# GENERAL_SECRETARY_ROLL=

--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import url
-from .views import HomeView, SocietyView, ClubView, SenateView, ContactListView, ContactView
+from .views import HomeView, SocietyView, ClubView, SenateView, ContactListView, ContactView, OfficeView
 
 app_name = 'main'
 
 urlpatterns = [
     url(r'^$', HomeView.as_view(), name='index'),
+    url(r'^office-bearers/$', OfficeView.as_view(), name='office-bearers'),
     url(r'^contact/$', ContactView.as_view(), name='contact'),
     url(r'^contact_list/$', ContactListView.as_view(), name='contact_list'),
     url(r'^society/(?P<slug>[\w-]+)/$', SocietyView.as_view(), name='soc-detail'),

--- a/src/templates/main/base.html
+++ b/src/templates/main/base.html
@@ -60,6 +60,9 @@
                             <li class="nav-item">
                                 <a class="nav-link waves-effect waves-light" href="{% url 'forum:index' %}">Forum</a>
                             </li>
+                            <li class="nav-item">
+                                <a class="nav-link waves-effect waves-light" href="{% url 'main:office-bearers' %}">People</a>
+                            </li>
                         </ul>
                         <!--Social Icons-->
                         <ul class="navbar-nav nav-flex-icons">

--- a/src/templates/main/index.html
+++ b/src/templates/main/index.html
@@ -80,6 +80,9 @@
                     <li class="nav-item">
                         <a class="nav-link waves-effect waves-light" href="{% url 'forum:index' %}">Forum</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link waves-effect waves-light" href="{% url 'main:office-bearers' %}">People</a>
+                    </li>
                 </ul>
 
                 <!--Social Icons-->

--- a/src/templates/main/office.html
+++ b/src/templates/main/office.html
@@ -1,0 +1,32 @@
+{% extends 'main/base.html' %}
+{% load staticfiles %}
+{% block main %}
+    <div class="container pt-5 section team-section">
+        <div class="row flex-center">
+            <div class="col-sm-10">
+                <!--Card Primary-->
+                <div class="card primary-color text-center z-depth-2 mt-2 mb-2">
+                    <div class="card-block">
+                        <h3 class="h3-responsive white-text mb-0">Office Bearers</h3>
+                    </div>
+                </div>
+                <!--/.Card Primary-->
+            </div>
+            {% if general_secretary %}
+                <div class="col-lg-4 col-md-6 pt-md-2 mb-r">
+                    {% include 'main/mixins/user_card_mixin.html' with userprofile=general_secretary designation='General Secretary' %}
+                </div>
+            {% endif %}
+            {% for society in societies %}
+                <div class="col-lg-4 col-md-6 pt-md-2 mb-r">
+                    {% include 'main/mixins/user_card_mixin.html' with userprofile=society.secretary designation=society.name|add:' Secretary' %}
+                </div>
+            {% endfor %}
+            {% if senate_secretary %}
+                <div class="col-lg-4 col-md-6 pt-md-2 mb-r">
+                    {% include 'main/mixins/user_card_mixin.html' with userprofile=senate_secretary designation='Student Elected Representative Society Secretary' %}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
### Description
The page listing all the office bearers has been added, currently general secretary can be added to the page by specifying a roll number in the `.env` configuration, in future it can be model driven.

Fixes #11 

### Screenshots
![screen shot 2018-09-12 at 1 35 31 am](https://user-images.githubusercontent.com/25402695/45384691-5246fb80-b62c-11e8-988e-a204762be18b.png)

### Type of Change:

- Code
- User Interface

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by maintainers)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [ ] I have commented my code or provided relevant documentation
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes