### PR TITLE
Fix contact card society name overflow

### DIFF
--- a/src/static/css/contact_card.css
+++ b/src/static/css/contact_card.css
@@ -7,6 +7,11 @@
     height: 40%;
 }
 
+.card-wrapper .detail-btn {
+    position: absolute;
+    margin-top: -1rem;
+}
+
 .section.team-section .avatar {
     margin-bottom: 0;
 }
@@ -45,4 +50,8 @@
 
 .section .front p {
     margin-bottom: 2.2rem;
+}
+
+.card-block .h-48 {
+    height: 48px;
 }

--- a/src/templates/forum/test.html
+++ b/src/templates/forum/test.html
@@ -71,7 +71,6 @@
 
     </div>
 
-
 </section>
     </div>
 <!--/Section: Contact v.1-->

--- a/src/templates/main/mixins/user_card_mixin.html
+++ b/src/templates/main/mixins/user_card_mixin.html
@@ -14,10 +14,12 @@
             </div>
             <!--Content-->
             <div class="card-block">
-                    <h4><a class="black-text" href="{{ userprofile.get_absolute_url }}">{{ userprofile.user.get_full_name|truncatewords:2 }}</a></h4>
-                <p>{{ designation|default:'' }}</p>
+                <h4><a class="black-text" href="{{ userprofile.get_absolute_url }}">{{ userprofile.user.get_full_name|truncatewords:2 }}</a></h4>
+                <p class = "h-48">{{ designation|default:''|truncatechars:75 }}</p>
                 <!--Triggering button-->
-                <a class="rotate-btn" data-card="card-{{ userprofile.id }}"><i class="fa fa-repeat"></i> Details</a>
+                <div class="flex-center">
+                    <a class="rotate-btn detail-btn" data-card="card-{{ userprofile.id }}"><i class="fa fa-repeat"></i> Details</a>
+                </div>
             </div>
         </div>
         <!--/.Front Side-->
@@ -33,7 +35,7 @@
                 </h5>
                 <h6 class="h6-responsive">
                     <a class="icons-sm email-ic" href="mailto:{{ userprofile.user.email }}">
-                    <i class="icons-sm-i fa fa-envelope-o"></i> {{ userprofile.user.email }}</a>
+                        <i class="icons-sm-i fa fa-envelope-o"></i> {{ userprofile.user.email }}</a>
                 </h6>
                 {{ userprofile.about|linebreaks }}
             </div>


### PR DESCRIPTION
### Description
Currently, on https://students.iitj.ac.in/office-bearers/ there is an overflow in some of the contact cards mainly due to the large length of society names of the office bearers and hence some of the following modifications have been made.

Fixes #25

### Type of Change:

- Code

**Code/Quality Assurance Only**

### Checklist:

- [x] My PR follows the style guidelines of this project
- [ ] I have commented my code or provided relevant documentation

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
- [ ] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes